### PR TITLE
importing gather from tidyr

### DIFF
--- a/R/imports.R
+++ b/R/imports.R
@@ -10,5 +10,5 @@
 #' @import dplyr
 #' @importFrom psych partial.r
 #' @import plotly
-#' @import tidyr gather
+#' @importFrom tidyr gather
 NULL


### PR DESCRIPTION
Hi, this is just a quick edit to rectify an error I ran into when attempting to install this package on a linux host. Here are the steps taken to reproduce this error:

``` bash
git clone https://github.com/CBIIT/R-cometsAnalytics
R -e "install.packages('R-cometsAnalytics', type = 'source', repos = NULL)"

* installing *source* package 'COMETS' ...
** R
** inst
** preparing package for lazy loading
Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
  there is no package called 'gather'
ERROR: lazy loading failed for package 'COMETS'
```
